### PR TITLE
Custom ID support

### DIFF
--- a/org-zettelkasten.el
+++ b/org-zettelkasten.el
@@ -15,7 +15,7 @@
 
 ;;; License:
 
-;; Copyright (C) 2020-2021  Yann Herklotz
+;; Copyright (C) 2020-2022  Yann Herklotz
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -48,7 +48,7 @@
 The value of this variable is checked as part of loading Zettelkasten mode.
 After that, changing the prefix key requires manipulating keymaps."
   :type 'key-sequence
-  :group 'zettelkasten)
+  :group 'org-zettelkasten)
 
 (defun org-zettelkasten-incr-id (ident)
   "Simple function to increment any IDENT.

--- a/zettelkasten.el
+++ b/zettelkasten.el
@@ -12,7 +12,7 @@
 
 ;;; License:
 
-;; Copyright (C) 2020-2021  Yann Herklotz
+;; Copyright (C) 2020-2022  Yann Herklotz
 ;;
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -211,12 +211,15 @@ This is deprecated in favour for `zettelkasten-list-notes'."
     (goto-char (point-max))
     (insert "\n" (zettelkasten--format-link note))))
 
-(defun zettelkasten--create-new-note-ni (title &optional parent)
+(defun zettelkasten--create-new-note-ni (title &optional parent custom-id)
   "Create a new note based on the TITLE and it's optional PARENT note.
 
-If PARENT is nil, it will not add a link from a PARENT."
+If PARENT is nil, it will not add a link from a PARENT.
+
+If CUSTOM-ID is not nil, will not generate a time-based ID but
+will use that instead."
   (let* ((note (zettelkasten--find-new-note-name
-                (format-time-string zettelkasten-file-format)))
+                (or custom-id (format-time-string zettelkasten-file-format))))
          (filename (zettelkasten--make-filename note)))
     (with-temp-buffer
       (set-visited-file-name filename)
@@ -403,6 +406,23 @@ Also see `zettelkasten--create-new-note-ni' for more information."
      title
      (unless (or prefix (not notes))
        (completing-read "Parent note: " notes nil 'match)))))
+
+(defun zettelkasten-create-new-custom-note (prefix)
+  "Create a new zettelkasten.
+
+If PREFIX is used, or if the `zettelkasten-directory' is empty,
+does not create a parent.
+
+Also see `zettelkasten--create-new-note-ni' for more information."
+  (interactive "P")
+  (let ((title (read-string "Note title: "))
+        (notes (zettelkasten--list-notes)))
+    (zettelkasten--create-new-note-ni
+     title
+     (unless (or prefix (not notes))
+       (completing-read "Parent note: " notes nil 'match))
+     (let ((id (read-string "Note ID: ")))
+       (if (string= id "") nil id)))))
 
 (defun zettelkasten-open-parent (&optional note)
   "Find the parent notes to the NOTE that is given.


### PR DESCRIPTION
Addresses #6 with a new function: `zettelkasten-create-new-custom-note`.  This note asks for a custom ID and falls back to a time-based one.