### PR TITLE
fix: Upgrade Python and checkout actions

### DIFF
--- a/.github/workflows/melpazoid.yml
+++ b/.github/workflows/melpazoid.yml
@@ -10,11 +10,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
-      with: { python-version: 3.9 }
+      uses: actions/setup-python@v5
+      with: { python-version: 3.13 }
 
     - name: Install
       run: |


### PR DESCRIPTION
Current melpazoid requires Python >= 3.10, otherwise, the GitHub Action fails. I set this up to use the current stable Python version which is 3.13.